### PR TITLE
fix var error of calendar.js

### DIFF
--- a/src/widget/calendar/calendar.js
+++ b/src/widget/calendar/calendar.js
@@ -139,7 +139,7 @@
 
                 case 'change':
                     elems = $('.ui-calendar-header .ui-calendar-year, ' +
-                        '.ui-calendar-header .ui-calendar-month', this._el);
+                        '.ui-calendar-header .ui-calendar-month', this.$el);
 
                     return this.switchMonthTo(getVal(elems.eq(1)), getVal(elems.eq(0)));
 


### PR DESCRIPTION
变量名错误，导致 elems 成了 $(selector)，当页面中存在两个以上的日历组件的时候，选择年月的值永远是第一个日历组件的。